### PR TITLE
Add terms.html

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,17 @@
+{{ define "head" }}
+<link rel="stylesheet" href='{{ "css/single.css" | absURL }}'>
+{{ end }}
+
+{{ define "main"}}
+<main id="main" class="tags">
+<div>
+<h1>Tags</h1>
+<br/>
+<center>
+   {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
+   <a class="link" href="{{ "tags/" | relLangURL }}{{ $name | urlize }}">{{ $name | title }}</a>&nbsp; &nbsp;
+   {{ end }}
+</center>
+</div>
+</main>
+{{end }}


### PR DESCRIPTION
By adding terms.html, you can display all the tags/categories applied in your blogs. The additional file is `/layouts/_default/terms.html`, which can be modified.

The image is below (I use categories rather than tags):

![image](https://user-images.githubusercontent.com/60024807/163552636-12530601-82c6-4f31-b0e6-827f49f13dd3.png)

Moreover, I noticed that the Archives page is a little loose, which can be a potential problem for large quantities of blogs. 